### PR TITLE
Fix/makedirs toctou

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/__pycache__
 data/model/*.csv
 venv
-GenZ_LLM_Analyzer.egg-info
+*.egg-info/
 dist/

--- a/GenZ/Models/get_language_model.py
+++ b/GenZ/Models/get_language_model.py
@@ -49,8 +49,9 @@ def save_layers(layers:list, data_path:str, name:str):
     model_path = os.path.join(data_path,"model")
     df = pd.DataFrame(layers, columns=['Name', 'M', 'N', 'D', 'H', 'Z', 'Z', 'T'])
     file_name = name.replace("/", "_") + datetime.now().strftime("%m_%d_%Y_%H_%M_%S") + str(uuid4()) +'.csv'
-    if not os.path.exists(model_path):
-        os.makedirs(model_path)
+    # exist_ok=True to avoid TOCTOU race when multiple worker processes
+    # call save_layers concurrently (ProcessPoolExecutor parallel stage sweep).
+    os.makedirs(model_path, exist_ok=True)
     df.to_csv(os.path.join(model_path, file_name),  header=True, index=None)
     return file_name
 


### PR DESCRIPTION
`save_layers` in `GenZ/Models/get_language_model.py` uses a check-then-create pattern for the model output directory:

```python
if not os.path.exists(model_path):
    os.makedirs(model_path)
```


This has a TOCTOU race: when multiple processes call save_layers concurrently (e.g. a ProcessPoolExecutor-based parallel stage sweep), one process can create model_path between another's exists() check and its makedirs() call, causing FileExistsError.

Fix
Use os.makedirs(model_path, exist_ok=True), which defers to the atomic mkdir(2) syscall and only swallows EEXIST — race-free, same semantics.

